### PR TITLE
Add comments detection using '#' to the lexer

### DIFF
--- a/pycell/lexer.py
+++ b/pycell/lexer.py
@@ -23,11 +23,17 @@ def _scan_string(delim, chars):
     return ret
 
 
+def _scan_comment(c, chars):
+    while c is not None and c != "\n":
+        c = chars.move_next()
+
+
 def lex(chars_iter):
     chars = PeekableStream(chars_iter)
     while chars.next is not None:
         c = chars.move_next()
         if c in " \n":              pass           # Ignore white space
+        elif c == "#":              _scan_comment(c, chars)
         elif c in "(){},;=:":       yield (c, "")  # Special characters
         elif c in "+-*/":           yield ("operation", c)
         elif c in ("'", '"'):       yield ("string", _scan_string(c, chars))

--- a/test.cell
+++ b/test.cell
@@ -1,0 +1,4 @@
+# this is a comment
+a=2;
+b=2;
+print(a+b);

--- a/tests/lexer_tests.py
+++ b/tests/lexer_tests.py
@@ -14,6 +14,10 @@ def lexed(inp):
 
 # --- Lexing ---
 
+@test
+def Comments_are_ignored():
+    assert_that(lexed("# this is a comment"), equals([]))
+
 
 @test
 def Empty_file_produces_nothing():


### PR DESCRIPTION
Hello (again). In cell specifications, there are no "comments". Of course we can use simple expressions like `"my string comment";` to document the code, but it forces the parser to process useless informations and include comments in the Syntax Tree.

This is why I suggest this little modification in the lexer. I also wrote tests in **tests/lexer_tests.py** 
and ensured that eveything works.